### PR TITLE
Clean up unused key definitions and stale comments

### DIFF
--- a/internal/tui/logic/update_input.go
+++ b/internal/tui/logic/update_input.go
@@ -492,10 +492,6 @@ func (h *Handler) handleKeyMsg(msg tea.KeyMsg) tea.Cmd {
 			h.StatusMsg = "Use 'S' to manage sections - select with Space, reorder with Shift+j/k"
 			return nil
 		}
-	// Note: 'C' key is not in keymap yet, handling manually or adding to keymap
-	// Actually, I should add 'C' to keymap or handle via raw key manually if I want.
-	// But let's assume I added 'C' -> 'add_comment' in keymap (I didn't yet).
-	// I'll add the case here assuming I will update keymap.go next.
 	case "add_comment":
 		if h.SelectedTask != nil {
 			h.IsAddingComment = true

--- a/internal/tui/state/keymap.go
+++ b/internal/tui/state/keymap.go
@@ -43,9 +43,7 @@ type KeymapData struct {
 	MoveTaskNextDay Key
 
 	// Navigation between panes
-	SwitchPane    Key
-	FocusTasks    Key
-	FocusProjects Key
+	SwitchPane Key
 
 	// Search/Filter
 	Search Key
@@ -96,9 +94,7 @@ func DefaultKeymap() KeymapData {
 		MoveTaskNextDay: Key{Key: ">", Help: "move +1 day"},
 
 		// Navigation between panes
-		SwitchPane:    Key{Key: "tab", Help: "switch pane"},
-		FocusTasks:    Key{Key: "t", Help: "focus tasks"},
-		FocusProjects: Key{Key: "p", Help: "focus projects"},
+		SwitchPane: Key{Key: "tab", Help: "switch pane"},
 
 		// Search
 		Search: Key{Key: "/", Help: "search"},


### PR DESCRIPTION
Analyzed the codebase and found a stale comment about an unmapped key which was actually mapped to a different key ('A'). Also identified and removed unused key definitions `FocusTasks` and `FocusProjects` from the keymap structure to clean up the code. Verified that the project still builds and tests pass.

---
*PR created automatically by Jules for task [4907514757981705880](https://jules.google.com/task/4907514757981705880) started by @Hy4ri*