### PR TITLE
Remove hardcoded user path in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@
 # Binary name
 BINARY_NAME=todoist-tui
 BINARY_PATH=bin/$(BINARY_NAME)
-LOCAL_PATH=~/.local/bin/$(BINARY_NAME)
 
 # Go parameters
 GOCMD=go
@@ -18,8 +17,6 @@ GOVET=$(GOCMD) vet
 # Build the binary
 build:
 	$(GOBUILD) -o $(BINARY_PATH) ./cmd/todoist-tui
-	rm -f $(LOCAL_PATH)
-	ln -s ~/Documents/Projects/todoist/$(BINARY_PATH) $(LOCAL_PATH)
 
 
 # Run in development mode


### PR DESCRIPTION
Removed hardcoded symlink creation in Makefile build target to improve portability.

---
*PR created automatically by Jules for task [210208007019486650](https://jules.google.com/task/210208007019486650) started by @Hy4ri*