### PR TITLE
Remove hardcoded user path from Makefile build target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,6 @@
 # Binary name
 BINARY_NAME=todoist-tui
 BINARY_PATH=bin/$(BINARY_NAME)
-LOCAL_PATH=~/.local/bin/$(BINARY_NAME)
 
 # Go parameters
 GOCMD=go
@@ -18,8 +17,6 @@ GOVET=$(GOCMD) vet
 # Build the binary
 build:
 	$(GOBUILD) -o $(BINARY_PATH) ./cmd/todoist-tui
-	rm -f $(LOCAL_PATH)
-	ln -s ~/Documents/Projects/todoist/$(BINARY_PATH) $(LOCAL_PATH)
 
 
 # Run in development mode


### PR DESCRIPTION
Removed the symlink creation step in the `build` target which used a hardcoded path (`~/Documents/Projects/todoist/`). The `build` target now only compiles the binary to `bin/todoist-tui`. Also removed the unused `LOCAL_PATH` variable.

---
*PR created automatically by Jules for task [5824486246917296267](https://jules.google.com/task/5824486246917296267) started by @Hy4ri*