### PR TITLE
Verify priority mapping logic and add tests

### DIFF
--- a/internal/tui/state/task_form.go
+++ b/internal/tui/state/task_form.go
@@ -216,13 +216,13 @@ func (f *TaskForm) ToCreateRequest() api.CreateTaskRequest {
 	desc := strings.TrimSpace(f.Description.Value())
 	due := strings.TrimSpace(f.DueString.Value())
 
-	// Priority mapping: UI 1-4 -> API 4-1
-	// UI P1 (Red) = 4, UI P2 (Orange) = 3, UI P3 (Blue) = 2, UI P4 (Grey) = 1
-	// Our internal Priority seems to match Todoist API directly?
-	// In view.go: priorityLabel := fmt.Sprintf("P%d", 5-t.Priority).
-	// If t.Priority is 4 (High), label is P1.
-	// So internal priority 4 = High.
-	// API AddParams uses Priority.
+	// Priority mapping:
+	// API/Internal: 4 (Urgent) -> UI: P1
+	// API/Internal: 3 (High)   -> UI: P2
+	// API/Internal: 2 (Medium) -> UI: P3
+	// API/Internal: 1 (Normal) -> UI: P4
+	//
+	// We use the API values (4-1) internally.
 
 	return api.CreateTaskRequest{
 		Content:     content,

--- a/internal/tui/state/task_form_test.go
+++ b/internal/tui/state/task_form_test.go
@@ -1,0 +1,82 @@
+package state
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/hy4ri/todoist-tui/internal/api"
+)
+
+func TestTaskForm_PriorityMapping(t *testing.T) {
+	// Setup
+	projects := []api.Project{}
+	labels := []api.Label{}
+	f := NewTaskForm(projects, labels)
+
+	// 1. Verify default priority (P4 = 1)
+	if f.Priority != 1 {
+		t.Errorf("Expected default priority to be 1 (P4), got %d", f.Priority)
+	}
+
+	// Focus priority field
+	f.Focus(FormFieldPriority)
+
+	// 2. Test input mapping
+	// Input "1" should map to Priority 4 (P1)
+	f.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("1")})
+	if f.Priority != 4 {
+		t.Errorf("Input '1' should set priority to 4 (P1), got %d", f.Priority)
+	}
+
+	// Input "2" should map to Priority 3 (P2)
+	f.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("2")})
+	if f.Priority != 3 {
+		t.Errorf("Input '2' should set priority to 3 (P2), got %d", f.Priority)
+	}
+
+	// Input "3" should map to Priority 2 (P3)
+	f.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("3")})
+	if f.Priority != 2 {
+		t.Errorf("Input '3' should set priority to 2 (P3), got %d", f.Priority)
+	}
+
+	// Input "4" should map to Priority 1 (P4)
+	f.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("4")})
+	if f.Priority != 1 {
+		t.Errorf("Input '4' should set priority to 1 (P4), got %d", f.Priority)
+	}
+}
+
+func TestTaskForm_ToCreateRequest_Priority(t *testing.T) {
+	projects := []api.Project{}
+	labels := []api.Label{}
+	f := NewTaskForm(projects, labels)
+
+	// Set priority to 4 (P1)
+	f.Priority = 4
+
+	req := f.ToCreateRequest()
+
+	if req.Priority != 4 {
+		t.Errorf("ToCreateRequest should preserve priority 4, got %d", req.Priority)
+	}
+}
+
+func TestTaskForm_ToUpdateRequest_Priority(t *testing.T) {
+	projects := []api.Project{}
+	labels := []api.Label{}
+	f := NewTaskForm(projects, labels)
+
+	// Set priority to 4 (P1)
+	f.Priority = 4
+
+	req := f.ToUpdateRequest()
+
+	if req.Priority == nil {
+		t.Fatal("ToUpdateRequest priority should not be nil")
+	}
+
+	if *req.Priority != 4 {
+		t.Errorf("ToUpdateRequest should preserve priority 4, got %d", *req.Priority)
+	}
+}


### PR DESCRIPTION
Verified the priority mapping between the internal state and the Todoist API. The internal state and API use values 4 (Urgent) to 1 (Normal). The UI displays these as P1 to P4 respectively.

Added unit tests to confirm this behavior and updated the code comments to be definitive about the mapping.

---
*PR created automatically by Jules for task [15286288982516066477](https://jules.google.com/task/15286288982516066477) started by @Hy4ri*